### PR TITLE
add ability to manually configure npm registry

### DIFF
--- a/src/npmfacade.js
+++ b/src/npmfacade.js
@@ -8,7 +8,7 @@ const runner = argv.mock ?
         return Promise.resolve(fs.readFileSync(`mock-${command.substr(0, 4)}.json`))
     }
     :
-    (command, opts) => promiseCommand('npm ' + command + ' --json', opts);
+    (command, opts) => promiseCommand('npm ' + command + ` --json ${argv.registry ? `--registry ${argv.registry}` : '' }`, opts)
 
 module.exports = {
     runNpmCommand(command, opts) {


### PR DESCRIPTION
Usage:  ```node check.js --registry  https://registry.npmjs.org/```

You might want to integrate this into a broader option pass through strategy, but this works as a starting point.