### PR TITLE
Support yarn

### DIFF
--- a/check.js
+++ b/check.js
@@ -1,8 +1,13 @@
 #!/usr/bin/env node
 const core = require("./index");
 const npmFacade = require('./src/npmfacade');
+const yarnManager = require('./src/yarn-manager')
 
-npmFacade.runNpmCommand('audit', { ignoreExit: true })
+yarnManager.addPackageLockFromYarnIfNecessary()
+    .then(() => {
+        return npmFacade.runNpmCommand('audit', { ignoreExit: true })
+    })
+    .then(yarnManager.removePackageLockIfNecessary)
     .then(input => {
         console.log(`Total of ${input.actions.length} actions to process`);
         return core.checkAudit(input)
@@ -30,5 +35,6 @@ npmFacade.runNpmCommand('audit', { ignoreExit: true })
     .then(() => console.log("audit ok."))
     .catch(e => {
         console.error(e);
-        process.exit(2);
+        yarnManager.removePackageLockIfNecessary()
+            .then(() => process.exit(2));
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@yarnpkg/lockfile": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ=="
+    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
@@ -45,6 +50,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colors": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
+      "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+    },
+    "commander": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
+      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
+    },
     "concat-stream": {
       "version": "1.6.2",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
@@ -65,6 +80,11 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
       "integrity": "sha1-dSMEvdxhdPSespy5iP7qC4gTyLw="
+    },
+    "eol": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/eol/-/eol-0.9.1.tgz",
+      "integrity": "sha512-Ds/TEoZjwggRoz/Q2O7SE3i4Jm66mqTDfmdHdq/7DKVk3bro9Q8h6WdXKdPqFLMoqxrDK5SVRzHVPOS6uuGtrg=="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -103,6 +123,14 @@
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+    },
+    "nmtree": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nmtree/-/nmtree-1.0.4.tgz",
+      "integrity": "sha512-kaYPfVNcc2RWh2EtT2MCBkkitgZbWM2OCfbq4Ji5jJPUrsm2L6xCTOWBIu/Rm1/v6sqvZFhBJtJcRp29IFcqDQ==",
+      "requires": {
+        "commander": "^2.11.0"
+      }
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -178,6 +206,18 @@
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "synp": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/synp/-/synp-1.3.2.tgz",
+      "integrity": "sha512-OFduB83xuXY0XGnEZJMPHICQ3oAprfsyjMEUX+/8Wy58vxf/va8ldC15Y0AIIur0UYfinlYdaAaw9LpWiJAn/w==",
+      "requires": {
+        "@yarnpkg/lockfile": "^1.0.0",
+        "colors": "^1.1.2",
+        "commander": "^2.11.0",
+        "eol": "^0.9.1",
+        "nmtree": "^1.0.3"
       }
     },
     "typedarray": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,9 +112,9 @@
       "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "merge-options": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.0.tgz",
-      "integrity": "sha1-W08zmpVxkrW5iZSjrFyV0splG5Q=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
       "requires": {
         "is-plain-obj": "^1.1"
       }
@@ -183,12 +183,12 @@
       "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "spawn-shell": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.0.1.tgz",
-      "integrity": "sha512-EYo5KSZYxTYzwGgughD9prtzk3kMJB6hpVhiAxmZPvUHLi8KWQHz/46LDydXsXwdSldgniNVtd1Ccia0Og3TfA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.1.0.tgz",
+      "integrity": "sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==",
       "requires": {
-        "default-shell": "^1.0.0",
-        "merge-options": "1.0.0",
+        "default-shell": "^1.0.1",
+        "merge-options": "~1.0.1",
         "npm-run-path": "^2.0.2"
       }
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "read": "^1.0.7",
     "semver": "^5.5.0",
     "spawn-shell": "^2.0.1",
+    "synp": "^1.3.2",
     "yargs-parser": "^10.0.0"
   },
   "devDependencies": {}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "concat-stream": "^1.6.2",
     "read": "^1.0.7",
     "semver": "^5.5.0",
-    "spawn-shell": "^2.0.1",
+    "spawn-shell": "^2.1.0",
     "synp": "^1.3.2",
     "yargs-parser": "^10.0.0"
   },

--- a/resolve.js
+++ b/resolve.js
@@ -1,11 +1,19 @@
 #!/usr/bin/env node
 const core = require('./index')
 const npmFacade = require('./src/npmfacade');
+const yarnManager = require('./src/yarn-manager')
 
-npmFacade.runNpmCommand('audit', { ignoreExit: true })
+yarnManager.addPackageLockFromYarnIfNecessary()
+    .then(() => {
+        return npmFacade.runNpmCommand('audit', { ignoreExit: true })
+    })
+    .then(yarnManager.removePackageLockIfNecessary)
     .then(input => {
         console.log(`Total of ${input.actions.length} actions to process`)
         return core.resolveAudit(input)
     })
     .then(() => console.log('done.'))
-    .catch(e => console.error(e));
+    .catch(e => {
+        console.error(e)
+        yarnManager.removePackageLockIfNecessary()
+    })

--- a/src/actions.js
+++ b/src/actions.js
@@ -2,6 +2,7 @@ const promiseCommand = require('./promiseCommand');
 const resolutionState = require('./resolutionState');
 const investigate = require('./investigate');
 const chalk = require('chalk')
+const argv = require('./arguments')
 
 function saveResolutionAll(action, resolution) {
     action.resolves.map(re => resolutionState.set(
@@ -43,6 +44,9 @@ const strategies = {
             }
             return mem
         }, {})).map(commandBit => {
+            if (argv.get().yarn) {
+                return promiseCommand(`yarn remove ${commandBit}`)
+            }
             return promiseCommand(`npm rm ${commandBit}`)
         })).then(() => { })
     },

--- a/src/prompter.js
+++ b/src/prompter.js
@@ -2,7 +2,7 @@ const promptly = require('./micro-promptly');
 const actions = require('./actions');
 const chalk = require('chalk')
 const argv = require('./arguments')
-
+const packageJSON = require(require('path').resolve('./package.json'))
 
 module.exports = {
     handleAction(action, advisories) {
@@ -133,6 +133,14 @@ function appendWarningLine(message, line) {
 function getCommand(action){
     // Derived from npm-audit-report
     // TODO: share the code
+    if (argv.get().yarn) {
+        if (action.action === 'install') {
+            const isDev = packageJSON.devDependencies[action.module] !== undefined;
+            return `yarn add ${isDev ? '--dev ' : ''}${action.module}@${action.target}`
+          } else {
+            return `yarn upgrade ${action.module}`
+        }
+    }
     if (action.action === 'install') {
         const isDev = action.resolves[0].dev
         return `npm install ${isDev ? '--save-dev ' : ''}${action.module}@${action.target}`

--- a/src/yarn-manager.js
+++ b/src/yarn-manager.js
@@ -1,0 +1,50 @@
+const yarnToNpm = require('synp').yarnToNpm
+const fs = require('fs')
+const argv = require('./arguments').get()
+
+function addPackageLockFromYarnIfNecessary() {
+    if (!argv.yarn) {
+        return true
+    }
+
+    console.log('Creating package-lock.json from yarn.lock')
+    const stringifiedPackageLock = yarnToNpm('.')
+    return new Promise((resolve, reject) => {
+        fs.writeFile('./package-lock.json', stringifiedPackageLock, (error) => {
+            if (error) {
+                return reject(error)
+            }
+
+            resolve()
+        })
+    })
+}
+
+function removePackageLockIfNecessary(input) {
+    if (!argv.yarn) {
+        return input
+    }
+    // Do nothing if package-lock does not exist
+    try {
+        fs.statSync('./package-lock.json')
+    } catch (e) {
+        return input;
+    }
+
+    console.log('Removing package-lock.json')
+    return new Promise((resolve, reject) => {
+        fs.unlink('./package-lock.json', (error) => {
+            if (error) {
+                return reject(error)
+            }
+
+            // Pass through original arguments
+            resolve(input)
+        })
+    })
+}
+
+module.exports = {
+    addPackageLockFromYarnIfNecessary,
+    removePackageLockIfNecessary,
+}


### PR DESCRIPTION
Hello!

I am very interested in this project and actually use `npm-audit-resolver` for two projects with NPM. However I have a large number on projects running yarn and the conversion cost is too big so I worked to make your package compatible with `yarn.lock` file.

This works by converting the `yarn.lock` file into `package-lock.json` with [synp](https://github.com/imsnif/synp) and use the `npm-audit-resolver` logic to know what to do next.

What do you think about it?

I added a lot of conditions between yarn and npm in the code and it becomes a bit unclear. I will be happy to refactor the code if you think this is needed.

Thank you