### PR TITLE
Add option for check-audit to output JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ check-audit
 
 This command will only exit with an error if a human needs to make new decisions about vulnerabilities and commit the `audit-resolv.json` file. If all issues are addressed, your build can pass.
 
+For JSON output (similar to `npm audit --json`), run
+```
+check-audit --json
+```
+
 ## Features
 
 Want to give it a go? Download this repo and run `npm test`

--- a/check.js
+++ b/check.js
@@ -1,33 +1,55 @@
 #!/usr/bin/env node
 const core = require("./index");
 const npmFacade = require('./src/npmfacade');
+const argv = require('./src/arguments').get();
+
+function auditOk(issues) {
+    return !(issues && issues.length);
+}
+
+function printHumanReadableReport(issues) {
+    if (auditOk(issues)) {
+        console.log("audit ok.");
+        return;
+    }
+    issues.forEach(issue => {
+        console.log(
+            `--------------------------------------------------`
+        );
+        console.log(`[${issue.severity}] ${issue.title}`);
+        console.log(issue.items.map(item => item.report).join("\n"));
+    })
+
+    console.log(
+        `--------------------------------------------------`
+    );
+    console.error(" 😱   Unresolved issues found!");
+    console.log(
+        `--------------------------------------------------`
+    );
+}
+
+function printJsonReport(issues) {
+    console.log(JSON.stringify(issues));
+}
 
 npmFacade.runNpmCommand('audit', { ignoreExit: true })
     .then(input => {
-        console.log(`Total of ${input.actions.length} actions to process`);
+        if (!argv.json) {
+            console.log(`Total of ${input.actions.length} actions to process`);
+        }
         return core.checkAudit(input)
     })
     .then(issues => {
-        if(issues && issues.length){
-            issues.forEach(issue => {
-                console.log(
-                    `--------------------------------------------------`
-                );
-                console.log(`[${issue.severity}] ${issue.title}`);
-                console.log(issue.items.map(item => item.report).join("\n"));
-            })
-
-            console.log(
-                `--------------------------------------------------`
-            );
-            console.error(" 😱   Unresolved issues found!");
-            console.log(
-                `--------------------------------------------------`
-            );
+        if (argv.json) {
+            printJsonReport(issues);
+        } else {
+            printHumanReadableReport(issues);
+        }
+        if (!auditOk(issues)) {
             process.exit(1);
         }
-    })
-    .then(() => console.log("audit ok."))
+})
     .catch(e => {
         console.error(e);
         process.exit(2);

--- a/check.js
+++ b/check.js
@@ -40,9 +40,10 @@ npmFacade.runNpmCommand('audit', { ignoreExit: true })
         }
         return core.checkAudit(input)
     })
-    .then(issues => {
+    .then(result => {
+        const { issues } = result;
         if (argv.json) {
-            printJsonReport(issues);
+            printJsonReport(result);
         } else {
             printHumanReadableReport(issues);
         }

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ const statusManager = require('./src/statusManager');
 const argv = require('./src/arguments')
 
 function countVulnerabilities(advisories, severity) {
-    return Object.values(advisories)
-        .reduce((count, advisory) => advisory.severity === severity ? count + 1 : count, 0);
+    return Object.keys(advisories)
+        .reduce((count, advisoryKey) => advisories[advisoryKey].severity === severity ? count + 1 : count, 0);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = {
         input.actions
             .map(statusManager.addStatus)
             .filter(a => {
-                if (a.humanReviewComplete) {
+                if (a.humanReviewComplete && !argv.get().json) {
                     console.log(
                         `skipping ${a.module} issue based on audit-resolv.json`
                     );

--- a/src/promiseCommand.js
+++ b/src/promiseCommand.js
@@ -1,9 +1,12 @@
 const spawnShell = require('spawn-shell');
 const concat = require('concat-stream');
+const argv = require('./arguments').get();
 
 
 module.exports = function promiseCommand (command, opts={}) {
-  console.log('>>>>', command)
+  if (!argv.json) {
+    console.log('>>>>', command);
+  }
   const pSpawn = spawnShell(command, Object.assign({
     stdio: [0, 'pipe', 2],
     env: process.env
@@ -23,7 +26,9 @@ module.exports = function promiseCommand (command, opts={}) {
     pSpawn.exitPromise
         .then((exitCode) => {
           if (opts.ignoreExit || exitCode === 0) {
-            console.log('>>>> exit:', exitCode)
+            if (!argv.json) {
+              console.log('>>>> exit:', exitCode)
+            }
             return
           } else {
             throw Error('Exit ' + exitCode)


### PR DESCRIPTION
This Pull Request adds a `--json` option to the `check-audit` command. When set, it:
- Outputs the audit results to `stdout` in JSON format, taking resolutions in `audit-resolv.json` into account, for programmatic use
- Silences some additional output
- Uses a format similar to the result of `npm audit --json` for consistency, but with appropriately filtered `actions`, `advisories` and `metadata`. This will allow scripts currently using `npm audit --json` to take advantage of `npm-audit-resolver`'s functionality with minimal effort.
- Includes a summarised `issues` property, courtesy of the processing `npm-audit-resolver` does
- Furthers the goal of aiding "automation in managing npm audit results" 😄 

/cc @naugtur @ranjeetkaur