### PR TITLE
Pass along (extra) arguments to npm-audit

### DIFF
--- a/check.js
+++ b/check.js
@@ -16,7 +16,7 @@ if (argv.yarn) {
     pkgFacade.setActiveImplementation('npm')
 }
 
-pkgFacade.getAudit({ shellOptions: { ignoreExit: true } })
+pkgFacade.getAudit({ argv, shellOptions: { ignoreExit: true } })
     .then(input => {
         if (!argv.json) {
             view.totalActions(input.actions.length)


### PR DESCRIPTION
It looks like all code is already in place to support this; including skipping flags that are used by npm-audit-resolver.
Actually pass the data along, so we can f.e. add --severity

[quick edit from github, still to be tested]