### PR TITLE
Upgrade chalk dep and rewrite code to use ESM

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "npm-audit-resolver",
   "version": "3.0.0-8",
-  "lockfileVersion": 3,
+  "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "npm-audit-resolver",
       "version": "3.0.0-8",
-      "license": "Apache 2.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@npmcli/ci-detect": "^3.0.2",
         "audit-resolve-core": "^3.0.0-3",
-        "chalk": "^4.1.2",
+        "chalk": "^5.2.0",
         "concat-stream": "^2.0.0",
         "djv": "^2.1.4",
         "jsonlines": "^0.1.1",
@@ -44,21 +44,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
     "node_modules/audit-resolve-core": {
       "version": "3.0.0-3",
       "resolved": "https://registry.npmjs.org/audit-resolve-core/-/audit-resolve-core-3.0.0-3.tgz",
@@ -89,38 +74,16 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==",
       "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
       "engines": {
-        "node": ">=10"
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
     },
     "node_modules/concat-stream": {
       "version": "2.0.0",
@@ -223,15 +186,6 @@
       "license": "BSD-3-Clause",
       "bin": {
         "flat": "cli.js"
-      }
-    },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/inherits": {
@@ -386,9 +340,9 @@
       }
     },
     "node_modules/readable-stream": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.1.tgz",
-      "integrity": "sha512-+rQmrWMYGA90yenhTYsLWAsLsqVC8osOw6PKE1HDYiO0gdPeKe/xDHNzIAIn4C91YQ6oenEhfYqqc1883qHbjQ==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "dependencies": {
         "inherits": "^2.0.3",
@@ -526,18 +480,6 @@
       ],
       "license": "MIT"
     },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -592,6 +534,371 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    }
+  },
+  "dependencies": {
+    "@korzio/djv-draft-04": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@korzio/djv-draft-04/-/djv-draft-04-2.0.1.tgz",
+      "integrity": "sha512-MeTVcNsfCIYxK6T7jW1sroC7dBAb4IfLmQe6RoCqlxHN5NFkzNpgdnBPR+/0D2wJDUJHM9s9NQv+ouhxKjvUjg==",
+      "optional": true
+    },
+    "@npmcli/ci-detect": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@npmcli/ci-detect/-/ci-detect-3.0.2.tgz",
+      "integrity": "sha512-P7nZG0skRVa9lH0OQmFG62CrzOySUiuPbKopjVAj3sXP0m1om9XfIvTp46h+NvlpTyd121JekiXFZj+1pnbm9g=="
+    },
+    "audit-resolve-core": {
+      "version": "3.0.0-3",
+      "resolved": "https://registry.npmjs.org/audit-resolve-core/-/audit-resolve-core-3.0.0-3.tgz",
+      "integrity": "sha512-37Qkk1EerVIzSF824BytESWeEtUcbAmdWyTGA/MqnHgVzO+PnU9oNqOpZTMst54xLpJci70Jszq/sLogqfvHmQ==",
+      "requires": {
+        "debug": "^4.3.1",
+        "djv": "^2.1.4",
+        "yargs-parser": "^21.0.0"
+      }
+    },
+    "buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA=="
+    },
+    "chalk": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.2.0.tgz",
+      "integrity": "sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA=="
+    },
+    "concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+      "integrity": "sha512-pTgQJ5KC0d2hcY8eyL1IzlBPYjTkyH72XRZPnLyKus2mBfNjQs3klqbJU2VILqZryAZUt9JOb3h/mWMy23/f5A==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^4.0.1",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
+    "debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "requires": {
+        "ms": "2.1.2"
+      }
+    },
+    "decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
+    },
+    "default-shell": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/default-shell/-/default-shell-1.0.1.tgz",
+      "integrity": "sha512-/Os8tTMPSriNHCsVj3VLjMZblIl1sIg8EXz3qg7C5K+y9calfTA/qzlfPvCQ+LEgLWmtZ9wCnzE1w+S6TPPFyQ=="
+    },
+    "djv": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/djv/-/djv-2.1.4.tgz",
+      "integrity": "sha512-giDn+BVbtLlwtkvtcsZjbjzpALHB77skiv3FIu6Wp8b5j8BunDcVJYH0cGUaexp6s0Sb7IkquXXjsLBJhXwQpA==",
+      "requires": {
+        "@korzio/djv-draft-04": "^2.0.1"
+      }
+    },
+    "flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "jsonlines": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsonlines/-/jsonlines-0.1.1.tgz",
+      "integrity": "sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA=="
+    },
+    "lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dev": true,
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "merge-options": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-options/-/merge-options-1.0.1.tgz",
+      "integrity": "sha512-iuPV41VWKWBIOpBsjoxjDZw8/GbSfZ2mk7N1453bwMrfzdrIk7EzBd+8UVR6rkw67th7xnk9Dytl3J+lHPdxvg==",
+      "requires": {
+        "is-plain-obj": "^1.1"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg=="
+        }
+      }
+    },
+    "ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+    },
+    "mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA=="
+    },
+    "npm-run-path": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+      "integrity": "sha512-lJxZYlT4DW/bRUtFh1MQIWqmLwQfAxnqWG4HhEdjMlkrJYnJn0Jrr2u3mgxqaWsdiBc76TYkTG/mhrnYTuzfHw==",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
+    },
+    "os-shim": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/os-shim/-/os-shim-0.1.3.tgz",
+      "integrity": "sha512-jd0cvB8qQ5uVt0lvCIexBaROw1KyKm5sbulg2fWOHjETisuCzWyt+eTZKEMs8v6HwzoGs8xik26jg7eCM6pS+A==",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha512-fEHGKCSmUSDPv4uoj8AlD+joPlq3peND+HRYyxFz4KPw4z926S/b8rIuFs2FYJg3BwsxJf6A9/3eIdLaYC+9Dw=="
+    },
+    "pre-commit": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-1.2.2.tgz",
+      "integrity": "sha512-qokTiqxD6GjODy5ETAIgzsRgnBWWQHQH2ghy86PU7mIn/wuWeTwF3otyNQZxWBwVn8XNr8Tdzj/QfUXpH+gRZA==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^5.0.1",
+        "spawn-sync": "^1.0.15",
+        "which": "1.2.x"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
+    },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==",
+      "dev": true
+    },
+    "read": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/read/-/read-2.0.0.tgz",
+      "integrity": "sha512-88JMmpeeRYzW9gvIpYyXlYadWanW4vB2CYtDDVBfbRpbSogUNjTWEBXxJXMIVFSLjWVdCcdcIjI3+VV3Z2e9mw==",
+      "requires": {
+        "mute-stream": "~1.0.0"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==",
+      "dev": true
+    },
+    "spawn-shell": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/spawn-shell/-/spawn-shell-2.1.0.tgz",
+      "integrity": "sha512-mjlYAQbZPHd4YsoHEe+i0Xbp9sJefMKN09JPp80TqrjC5NSuo+y1RG3NBireJlzl1dDV2NIkIfgS6coXtyqN/A==",
+      "requires": {
+        "default-shell": "^1.0.1",
+        "merge-options": "~1.0.1",
+        "npm-run-path": "^2.0.2"
+      }
+    },
+    "spawn-sync": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/spawn-sync/-/spawn-sync-1.0.15.tgz",
+      "integrity": "sha512-9DWBgrgYZzNghseho0JOuh+5fg9u6QWhAWa51QC7+U5rCheZ/j1DrEZnyE0RBBRqZ9uEXGPgSSM0nky6burpVw==",
+      "dev": true,
+      "requires": {
+        "concat-stream": "^1.4.7",
+        "os-shim": "^0.1.2"
+      },
+      "dependencies": {
+        "concat-stream": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+          "dev": true,
+          "requires": {
+            "buffer-from": "^1.0.0",
+            "inherits": "^2.0.3",
+            "readable-stream": "^2.2.2",
+            "typedarray": "^0.0.6"
+          }
+        },
+        "readable-stream": {
+          "version": "2.3.8",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+          "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+          "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+        }
+      }
+    },
+    "typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "which": {
+      "version": "1.2.14",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
+      "integrity": "sha512-16uPglFkRPzgiUXYMi1Jf8Z5EzN1iB4V0ZtMXcHZnwsBtQhhHeCqoWw7tsUY42hJGNDWtUsVLTjakIa5BgAxCw==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==",
+      "dev": true
+    },
+    "yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="
+    },
+    "yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "requires": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "check",
     "resolve"
   ],
+  "type": "module",
   "author": "naugtur <naugtur@gmail.com>",
   "repository": {
     "type": "git",
@@ -32,11 +33,11 @@
     "url": "https://github.com/naugtur/npm-audit-resolver/issues"
   },
   "homepage": "https://github.com/naugtur/npm-audit-resolver#readme",
-  "license": "Apache 2.0",
+  "license": "Apache-2.0",
   "dependencies": {
     "@npmcli/ci-detect": "^3.0.2",
     "audit-resolve-core": "^3.0.0-3",
-    "chalk": "^4.1.2",
+    "chalk": "^5.2.0",
     "concat-stream": "^2.0.0",
     "djv": "^2.1.4",
     "jsonlines": "^0.1.1",

--- a/resolve.js
+++ b/resolve.js
@@ -1,27 +1,30 @@
 #!/usr/bin/env node
-const isCi = require('@npmcli/ci-detect')();
-const pkgFacade = require('./src/pkgFacade');
-const view = require('./src/views/general')
-const argv = require('./src/arguments').get();
-const auditResolver = require('./src/resolve/auditResolver')
+import ciDetect from '@npmcli/ci-detect';
+import pkgFacade from './src/pkgFacade/index.js';
+import view from './src/views/general.js';
+import _args from 'audit-resolve-core/arguments.js';
+import auditResolver from './src/resolve/auditResolver.js';
+
+const argv = _args.get();
+const isCi = ciDetect();
 
 if (isCi && !argv.trustmeitsnotci) {
     view.ciDetected()
     process.exit(1)
 }
 
-if (argv.yarn) {
-    pkgFacade.addImplementation('yarn', require('./src/pkgmanagers/yarn'))
-    pkgFacade.setActiveImplementation('yarn')
-} else if (argv["yarn-berry"]) {
-    pkgFacade.addImplementation('yarn-berry', require('./src/pkgmanagers/yarnBerry'))
-    pkgFacade.setActiveImplementation('yarn-berry')
-} else {
-    pkgFacade.addImplementation('npm', require('./src/pkgmanagers/npm'))
-    pkgFacade.setActiveImplementation('npm')
-}
+// if (argv.yarn) {
+//     pkgFacade.addImplementation('yarn', require('./src/pkgmanagers/yarn'))
+//     pkgFacade.setActiveImplementation('yarn')
+// } else if (argv["yarn-berry"]) {
+//     pkgFacade.addImplementation('yarn-berry', require('./src/pkgmanagers/yarnBerry'))
+//     pkgFacade.setActiveImplementation('yarn-berry')
+// } else {
+//     pkgFacade.addImplementation('npm', require('./src/pkgmanagers/npm'))
+//     pkgFacade.setActiveImplementation('npm')
+// }
 
-pkgFacade.getAudit({ shellOptions: { ignoreExit: true } })
+pkgFacade.init().then(() => pkgFacade.getAudit({ shellOptions: { ignoreExit: true } })
     .then(async input => {
         const choice = await auditResolver.askForFix(input)
         if (choice === 'f') {
@@ -36,4 +39,4 @@ pkgFacade.getAudit({ shellOptions: { ignoreExit: true } })
     .catch(e => {
         view.genericError(e);
         process.exit(2);
-    });
+    }));

--- a/src/arguments.js
+++ b/src/arguments.js
@@ -1,6 +1,8 @@
-var argv = require('yargs-parser')(process.argv.slice(2));
+import yargsParser from 'yargs-parser';
 
-module.exports = {
+let argv = yargsParser(process.argv.slice(2));
+
+export default {
     get: () => argv,
     set: a => {
         if (a) { argv = a }

--- a/src/check/auditChecker.js
+++ b/src/check/auditChecker.js
@@ -1,34 +1,33 @@
-const { getResolution, RESOLUTIONS } = require('audit-resolve-core');
+import auditResolveCore from 'audit-resolve-core';
 
+const { getResolution, RESOLUTIONS } = auditResolveCore;
 
-module.exports = {
-    /**
-     *
-     *
-     * @param {Array<Vuln>} audit
-     * @returns {Array<VulnResolution} 
-     */
-    getUnresolved(audit = []) {
-        return audit.map(item => {
-            let unresolved = false;
-            item.resolutions = item.paths.map(path => {
-                const resolution = getResolution({ id: item.id, path })
-                if (resolution) {
-                    if (resolution === RESOLUTIONS.EXPIRED) {
-                        unresolved = true
-                    }
-                    if (resolution === RESOLUTIONS.NONE) {
-                        unresolved = true
-                    }
-                } else {
+/**
+ *
+ *
+ * @param {Array<Vuln>} audit
+ * @returns {Array<VulnResolution}
+ */
+export default function getUnresolved(audit = []) {
+    return audit.map(item => {
+        let unresolved = false;
+        item.resolutions = item.paths.map(path => {
+            const resolution = getResolution({ id: item.id, path })
+            if (resolution) {
+                if (resolution === RESOLUTIONS.EXPIRED) {
                     unresolved = true
                 }
-                return { path, resolution }
-
-            })
-            if (unresolved) {
-                return item
+                if (resolution === RESOLUTIONS.NONE) {
+                    unresolved = true
+                }
+            } else {
+                unresolved = true
             }
-        }).filter(a => a);
-    }
+            return { path, resolution }
+
+        })
+        if (unresolved) {
+            return item
+        }
+    }).filter(a => a);
 }

--- a/src/pkgFacade/index.js
+++ b/src/pkgFacade/index.js
@@ -1,5 +1,7 @@
-const argv = require('../arguments').get()
-const promiseCommand = require('../promiseCommand');
+import _args from 'audit-resolve-core/arguments.js';
+import { promiseCommand } from '../promiseCommand.js';
+
+const argv = _args.get();
 
 let currentActiveRunner;
 function setActiveImplementation(name) {
@@ -8,12 +10,32 @@ function setActiveImplementation(name) {
 
 const runners = {
 }
+
 function runner(pkgmanager) {
     pkgmanager = pkgmanager || currentActiveRunner
     return runners[pkgmanager]
 }
 
-module.exports = {
+export default {
+    async init() {
+        if (argv.yarn) {
+            const { default: yarn } = await import('../pkgmanagers/yarn.js');
+
+            this.addImplementation('yarn', yarn)
+            this.setActiveImplementation('yarn')
+        } else if (argv["yarn-berry"]) {
+            const { default: yarnBerry } = await import('../pkgmanagers/yarnBerry.js');
+
+            this.addImplementation('yarn-berry', yarnBerry)
+            this.setActiveImplementation('yarn-berry')
+        } else {
+            const { default: npm } = await import('../pkgmanagers/npm.js');
+
+            this.addImplementation('npm', npm)
+            this.setActiveImplementation('npm')
+        }
+    },
+
     addImplementation(name, implementation) {
         if (!typeof implementation.getAudit === 'function') {
             throw Error('Package Manager implementation must expose a getAudit function returning a promise for audit data.')
@@ -21,6 +43,7 @@ module.exports = {
         if (!implementation.version === 1) {
             throw Error(`expected version to be set to 1 on implementation, got ${implementation.version} instead`)
         }
+
         runners[name] = implementation
         // enable first by default
         if (!currentActiveRunner) {
@@ -36,7 +59,7 @@ module.exports = {
      * @returns {Promise<Array<Vuln>>} list of vulnerabilities
      */
     getAudit({ pkgmanager, shellOptions }) {
-        return runner(pkgmanager).getAudit({
+        return this.init().then(() => runner(pkgmanager).getAudit({
             promiseCommand,
             argv: Object.assign({}, argv),
             shellOptions
@@ -52,7 +75,7 @@ module.exports = {
                 console.error(output)
                 throw e;
             }
-        })
+        }));
         //TODO: assert valid output format
     },
     remove({ pkgmanager, shellOptions, names }) {

--- a/src/pkgmanagers/npm.js
+++ b/src/pkgmanagers/npm.js
@@ -1,6 +1,5 @@
-const unparse = require('../unparse')
-const skipArgs = require('../skipArgs')
-
+import unparse from '../unparse.js';
+import skipArgs from '../skipArgs.js';
 
 function reformatFromV2(input) {
     const vulns = input.vulnerabilities;
@@ -108,7 +107,7 @@ const handleOutput = (of, output) => {
     return parsed
 }
 
-module.exports = {
+export default {
     version: 1,
     getAudit({ promiseCommand, argv, shellOptions }) {
         const unparsed = unparse(argv, skipArgs)

--- a/src/pkgmanagers/yarn.js
+++ b/src/pkgmanagers/yarn.js
@@ -1,9 +1,8 @@
-const jsonlines = require('jsonlines')
-const unparse = require('../unparse')
-const skipArgs = require('../skipArgs')
+import jsonlines from 'jsonlines';
+import unparse from '../unparse.js';
+import skipArgs from '../skipArgs.js';
 
-
-module.exports = {
+export default {
     version: 1,
     getAudit({ promiseCommand, argv, shellOptions }) {
         const unparsed = unparse(argv, skipArgs)

--- a/src/pkgmanagers/yarnBerry.js
+++ b/src/pkgmanagers/yarnBerry.js
@@ -1,8 +1,7 @@
-const unparse = require('../unparse')
-const skipArgs = require('../skipArgs')
+import unparse from '../unparse.js';
+import skipArgs from '../skipArgs.js';
 
-
-module.exports = {
+export default {
     version: 1,
     getAudit({ promiseCommand, argv, shellOptions }) {
         const unparsed = unparse(argv, skipArgs)

--- a/src/promiseCommand.js
+++ b/src/promiseCommand.js
@@ -1,7 +1,9 @@
-const spawnShell = require('spawn-shell');
-const concat = require('concat-stream');
-const argv = require('./arguments').get();
-const fs = require('fs')
+import spawnShell from 'spawn-shell';
+import concat from 'concat-stream';
+import _args from 'audit-resolve-core/arguments.js';
+import fs from 'node:fs';
+
+const argv = _args.get();
 
 function readMock(file, command) {
   command = command.trim()
@@ -16,7 +18,8 @@ function readMock(file, command) {
     return JSON.stringify(commandOutput)
   }
 }
-module.exports = function promiseCommand(command, opts = {}) {
+
+export function promiseCommand(command, opts = {}) {
   if (argv.mock) {
     if (typeof argv.mock === 'string') {
       console.error(`>>mock>> '${command}'`);

--- a/src/resolve/actions.js
+++ b/src/resolve/actions.js
@@ -1,11 +1,16 @@
-const pkgFacade = require('../pkgFacade')
+import pkgFacade from '../pkgFacade/index.js';
 // const investigate = require('../investigate');
-const view = require('../views/decisions')
-const { RESOLUTIONS, saveResolution } = require('audit-resolve-core')
-const ONE_WEEK_LATER = Date.now() + 7 * 24 * 60 * 60 * 1000
-const TWO_WEEKS_LATER = Date.now() + 14 * 24 * 60 * 60 * 1000
-const MONTH_LATER = Date.now() + 30 * 24 * 60 * 60 * 1000
-const NEVER = undefined
+import view from '../views/decisions.js';
+import auditResolveCore from 'audit-resolve-core';
+import statusManager from 'audit-resolve-core/statusManager.js';
+
+const ONE_WEEK_LATER = Date.now() + 7 * 24 * 60 * 60 * 1000;
+const TWO_WEEKS_LATER = Date.now() + 14 * 24 * 60 * 60 * 1000;
+const MONTH_LATER = Date.now() + 30 * 24 * 60 * 60 * 1000;
+const NEVER = undefined;
+
+const { RESOLUTIONS } = auditResolveCore;
+const { saveResolution } = statusManager;
 
 function getIdentifiers(vuln) {
     return vuln.paths.map(path => ({ path, id: vuln.id }))
@@ -79,7 +84,7 @@ function strategyOf(choice) {
     return strategies[choice] || noop;
 }
 
-module.exports = {
+export default {
     /**
      *
      *

--- a/src/resolve/auditResolver.js
+++ b/src/resolve/auditResolver.js
@@ -1,10 +1,12 @@
-const { getUnresolved } = require('../check/auditChecker')
-const { load, flush } = require('audit-resolve-core/auditFile');
-const argv = require('audit-resolve-core/arguments').get();
+import auditFile from 'audit-resolve-core/auditFile/index.js';
+import _args from 'audit-resolve-core/arguments.js';
+import getUnresolved from '../check/auditChecker.js';
+import prompter from './prompter.js';
 
-const prompter = require('./prompter');
+const argv = _args.get();
+const { load, flush } = auditFile;
 
-module.exports = {
+export default {
     /**
      *
      *
@@ -26,7 +28,7 @@ module.exports = {
     },
     askForFix(audit) {
         const unresolved = getUnresolved(audit)
-        
+
         if(unresolved && unresolved.length>0 && unresolved.some(vuln => vuln.fixAvailable)) {
             return prompter.askToFix(unresolved)
         }

--- a/src/resolve/micro-promptly.js
+++ b/src/resolve/micro-promptly.js
@@ -1,6 +1,6 @@
 // I wanted to use promptly, but it uses {...options} syntax, so it wouldn't work in node6
-// This implements the API subset I use 
-const read = require('read')
+// This implements the API subset I use
+import read from 'read';
 
 function validate(choices, resp) {
     if (choices.indexOf(resp) > -1) {
@@ -20,6 +20,6 @@ function choose(text, choices, options) {
         })
 }
 
-module.exports = {
+export default {
     choose
-}
+};

--- a/src/resolve/prompter.js
+++ b/src/resolve/prompter.js
@@ -1,8 +1,11 @@
-const promptly = require('./micro-promptly');
-const actions = require('./actions');
-const argv = require('audit-resolve-core/arguments').get()
-const view = require('../views/decisions')
-const rules = require('audit-resolve-core/auditFile').getRules()
+import promptly from './micro-promptly.js';
+import actions from './actions.js';
+import _args from 'audit-resolve-core/arguments.js';
+import view from '../views/decisions.js';
+import auditFile from 'audit-resolve-core/auditFile/index.js';
+
+const rules = auditFile.getRules()
+const argv = _args.get();
 
 /**
  *
@@ -74,7 +77,7 @@ async function optionsPrompt({ vuln }, choices = null) {
     }
 }
 
-module.exports = {
+export default {
     /**
      *
      *
@@ -98,7 +101,5 @@ module.exports = {
             key: 'f',
             name: 'Run: npm/yarn audit fix'
         }])
-
-
     }
 };

--- a/src/skipArgs.js
+++ b/src/skipArgs.js
@@ -1,1 +1,1 @@
-module.exports = ['json', 'migrate', 'yarn', 'yarn-berry', 'yarnBerry', 'mock', 'fix', 'trustmeitsnotci']
+export default ['json', 'migrate', 'yarn', 'yarn-berry', 'yarnBerry', 'mock', 'fix', 'trustmeitsnotci'];

--- a/src/unparse.js
+++ b/src/unparse.js
@@ -1,6 +1,6 @@
-const yargsUnparse = require('yargs-unparser');
+import yargsUnparse from 'yargs-unparser';
 
-function unparse(argv, filteredKeys = []) {
+export default function unparse(argv, filteredKeys = []) {
     const filteredArgs = Object.assign({}, argv);
     
     filteredKeys.forEach(key => {
@@ -12,4 +12,3 @@ function unparse(argv, filteredKeys = []) {
     // I hope it doesn't hurt later :|
     return unparsed.replace('--omit ','--omit=');
 }
-module.exports = unparse;

--- a/src/views/decisions.js
+++ b/src/views/decisions.js
@@ -1,5 +1,7 @@
-const chalk = require('chalk')
-const RESOLUTIONS = require('audit-resolve-core/resolutions/RESOLUTIONS')
+import chalk from 'chalk';
+import auditResolveCore from 'audit-resolve-core';
+
+const { RESOLUTIONS } = auditResolveCore;
 
 const colors = {
     critical: chalk.bold.white.bgRedBright,
@@ -10,9 +12,7 @@ function getSeverityTag(item) {
     const color = colors[item.severity] || (a => a);
     return color(`[ ${item.severity} ]`)
 }
-
-
-reportMessages = {
+const reportMessages = {
     [RESOLUTIONS.EXPIRED]: chalk.magenta("! decision to ignore expired"),
 }
 
@@ -20,7 +20,7 @@ function reportResolution(resolution) {
     return reportMessages[resolution] || ""
 }
 
-module.exports = {
+export default {
     printDecision(text = '') {
         console.log(`Selected: ${text}`)
     },

--- a/src/views/general.js
+++ b/src/views/general.js
@@ -11,4 +11,5 @@ const view = {
     }
 
 }
-module.exports = view
+
+export default view;

--- a/src/views/package.js
+++ b/src/views/package.js
@@ -1,6 +1,9 @@
-const { RESOLUTIONS } = require('audit-resolve-core');
+import auditResolveCore from 'audit-resolve-core';
+import util from 'node:util';
 
-const safePrint = require('util').promisify(process.stdout.write.bind(process.stdout))
+const { RESOLUTIONS } = auditResolveCore;
+
+const safePrint = util.promisify(process.stdout.write.bind(process.stdout))
 const severityNumber = {
     low: 10,
     moderate: 20,
@@ -8,9 +11,9 @@ const severityNumber = {
     critical: 40
 }
 
-reportMessages = {
+const reportMessages = {
     [RESOLUTIONS.EXPIRED]: "! decision to ignore expired"
-}
+};
 
 function reportResolution(resolution) {
     return reportMessages[resolution] || ""
@@ -56,6 +59,6 @@ const view = {
     printJsonReportAsync(issues) {
         return safePrint(JSON.stringify(issues, null, 2));
     }
-
 }
-module.exports = view
+
+export default view;

--- a/test/e2e/test.js
+++ b/test/e2e/test.js
@@ -1,5 +1,5 @@
-const promiseCommand = require('../../src/promiseCommand')
-const assert = require('assert');
+import { promiseCommand } from '../../src/promiseCommand.js';
+import assert from 'node:assert/strict';
 
 function announce(title) {
     console.log(`\n╭${'─'.repeat(title.length + 2)}╮\n│`, title, `│\n╰${'─'.repeat(title.length + 2)}╯\n`)
@@ -7,7 +7,13 @@ function announce(title) {
 
 async function commandSequence(arr, opts={}) {
     for (let i = 0; i < arr.length; i++) {
-        await promiseCommand(arr[i], opts)
+        try {
+            await promiseCommand(arr[i], opts)
+        } catch(e) {
+            console.log(e);
+            throw e;
+        }
+
     }
 }
 
@@ -130,6 +136,7 @@ async function run() {
 
     announce('               test.js - all passed                 ')
 }
-run()
+
+run();
 
 


### PR DESCRIPTION
Hi @naugtur this PR updates npm7 release branch and hopefully addresses your last point: upgrading packages.

I did an upgrade of chalk, chalk is now an only ESM package. I've updated the codebase and removed all the require (commonjs) imports and changed them to ESM.

All tests seem to run fine! Another small change to the license field as it was complaining that is was not SPDX compatible. So I've set the correct license identifier for Apache 2.0.

